### PR TITLE
解决 OOM 场景下触发的对象空异常

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -5231,6 +5231,9 @@ static force_inline JSShapeProperty *find_own_property(JSProperty **ppr,
     JSShapeProperty *pr, *prop;
     intptr_t h;
     sh = p->shape;
+    if (sh == NULL) {
+        return NULL;
+    }
     h = (uintptr_t)atom & sh->prop_hash_mask;
     h = prop_hash_end(sh)[-h - 1];
     prop = get_shape_prop(sh);
@@ -8059,6 +8062,9 @@ static JSProperty *add_property(JSContext *ctx,
     JSShape *sh, *new_sh;
 
     sh = p->shape;
+    if(sh == NULL) {
+        return NULL;
+    }
     if (sh->is_hashed) {
         /* try to find an existing shape */
         new_sh = find_hashed_shape_prop(ctx->rt, sh, prop, prop_flags);


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 通过在 'find_own_property' 和 'add_property' 函数中添加对空形状的检查，修复在内存不足（OOM）条件下触发的空指针异常。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix a null pointer exception triggered under out-of-memory (OOM) conditions by adding checks for null shapes in the 'find_own_property' and 'add_property' functions.

</details>